### PR TITLE
Edits: OSF Guidelines

### DIFF
--- a/docs/osf/guidelines.rst
+++ b/docs/osf/guidelines.rst
@@ -93,6 +93,7 @@ Responses
  **TODO**: Come up with a standard format. The Dropbox add-on uses the following, though we may decide on a different convention later.
 
 ::
+
     {
         "result": {"name": "New Project", "id": ...} # ... the requested object(s) ,
         "message": "Successfully created project" # ... an optional message


### PR DESCRIPTION
Updates OSF Guidelines to include the usage of `web_url_for` and `api_url_for` in Mako templates.

Also fixes a small typo resulting in a codeblock failing to render properly on the same page.
