### PR TITLE
Fix broken HuBoard link

### DIFF
--- a/docs/process/issues.rst
+++ b/docs/process/issues.rst
@@ -12,4 +12,4 @@ Columns are defined as follows:
 - **Ready to Merge**: Code review complete, all appropriate tests are written and passing. Ready to merge into COS/develop and deploy to staging.
 - **On Staging**: Feature is on staging server, ready for manual testing
 
-.. _HuBoard: https://huboard.com/CenterForOpenScience/openscienceframework.org#/
+.. _HuBoard: https://huboard.com/CenterForOpenScience/


### PR DESCRIPTION
The existing link points to a HuBoard page that no longer exists, or has been renamed.

Additionally, as COS grows, these dev docs apply to more than just the OSF. The fixed link points to the organization instead of one specific project.

Confirmed builds correctly with Sphinx.