### PR TITLE
Add work around for uritemplate conflict that causes fail on setup

### DIFF
--- a/docs/osf/setup.rst
+++ b/docs/osf/setup.rst
@@ -339,7 +339,15 @@ Building assets with ``webpack``
 ::
 
     inv assets -dw
+    
+If invoking assets or server commands throw an error about uritemplate, run the following to resolve the conflict:
 
+    ::
+
+        pip uninstall uritemplate.py --yes
+        pip install uritemplate.py==0.3.0
+
+and then re run the command that failed.
 
 Installing Add on Requirements
 ------------------------------


### PR DESCRIPTION
This comes from my experience in setting up the OSF, and someone this weekend with the same problem. The solution comes from our `.travis.yml`