### PR TITLE
Update link to airbnb's JS style guide

### DIFF
--- a/docs/style_guides/javascript.rst
+++ b/docs/style_guides/javascript.rst
@@ -11,7 +11,7 @@ Style guidelines for writing Javascript.
 Style
 *****
 
-Follow `Felix's Node Style <https://github.com/felixge/node-style-guide>`_ and `airbnb's Style Guide <https://github.com/airbnb/javascript>`_ with a few exceptions:
+Follow `Felix's Node Style <https://github.com/felixge/node-style-guide>`_ and `airbnb's Style Guide <https://github.com/airbnb/javascript/tree/master/es5>`_ with a few exceptions:
 
 - Use **4 spaces** for indentation.
 - Use ``self`` to save a reference to ``this``.


### PR DESCRIPTION
airbnb's javascript style guide has been updated for ES6, and their ES5 guide has moved to a subdirectory. Since we're still an ES5 shop, update the link to point to ES5.
