### PR TITLE
Fix typos and old links

### DIFF
--- a/docs/osf/testing.rst
+++ b/docs/osf/testing.rst
@@ -176,7 +176,7 @@ Regression tests may fall under any one of the categories above (unit, model, vi
 
 .. code-block:: python
 
-    # Regression test for https://github.com/CenterForOpenScience/openscienceframework.org/issues/1136
+    # Regression test for https://github.com/CenterForOpenScience/osf.io/issues/1136
     def test_cannot_create_project_with_blank_name(self):
         # ...
 

--- a/docs/process/pull_requests.rst
+++ b/docs/process/pull_requests.rst
@@ -34,7 +34,7 @@ Purpose
 
 Currently, the only way to add projects to your Dashboard's Project Organizer is from within the project organizer. There are smart folders with your projects and registrations, and you can search for projects from within the info widget to add to folders, but if you are elsewhere in the OSF, it's a laborious process to get the project into the Organizer. This PR allows you to be on a project and add the current project to the Project Organizer.
 
-Closes Issue https://github.com/CenterForOpenScience/openscienceframework.org/issues/1186
+Closes Issue https://github.com/CenterForOpenScience/osf.io/issues/1186
 
 Changes
 -------

--- a/docs/style_guides/git.rst
+++ b/docs/style_guides/git.rst
@@ -21,7 +21,7 @@ Git
 
   Fix bug in loading filetree
 
-  [fix CenterForOpenScience/openscienceframework.org#982]
+  [fix CenterForOpenScience/osf.io#982]
 
 - Write `good commit messages <http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_.
 

--- a/docs/style_guides/python.rst
+++ b/docs/style_guides/python.rst
@@ -244,7 +244,7 @@ Use `super` when there is only one superclass.
 
         def __init__(self, name):
             super(Employee, self).__init__(name)
-            # or super().__init__(name) on Python 3
+            # or super().__init__(name) in Python 3
             # ...
 
 


### PR DESCRIPTION
Fix a few small issues I found while getting set up:

* "*on* Python 3" -> "*in* Python 3"
* openscienceframework.org -> osf.io